### PR TITLE
Fix PG connection

### DIFF
--- a/app/services.boot.js
+++ b/app/services.boot.js
@@ -27,9 +27,9 @@ const appServices = (module.exports = {});
 appServices.boot = async (bootOpts) => {
   log.notice('Booting Services...');
 
-  await postgresService.init();
-
   await migrationService.runHerokuMigration();
+
+  await postgresService.init();
 
   await expressService.init(bootOpts);
 

--- a/app/services/migration.service.js
+++ b/app/services/migration.service.js
@@ -17,7 +17,7 @@ migrationService.runHerokuMigration = async () => {
     return;
   }
   log.info('runHerokuMigration() Init');
-  const db = Knex(knexConfig);
+  const db = Knex(knexConfig());
 
   try {
     await db.migrate.latest();

--- a/app/services/postgres.service.js
+++ b/app/services/postgres.service.js
@@ -23,6 +23,7 @@ sqldb.knexConfig = {
     min: config.postgres.pool_min,
     max: config.postgres.pool_max,
   },
+  ssl: false,
 };
 
 /**

--- a/app/services/postgres.service.js
+++ b/app/services/postgres.service.js
@@ -23,7 +23,7 @@ sqldb.knexConfig = {
     min: config.postgres.pool_min,
     max: config.postgres.pool_max,
   },
-  ssl: false,
+  ssl: { rejectUnauthorized: false },
 };
 
 /**

--- a/app/services/postgres.service.js
+++ b/app/services/postgres.service.js
@@ -4,6 +4,7 @@
 const config = require('config');
 const knex = require('knex');
 
+const globals = require('../utils/globals');
 const log = require('./log.service').get();
 
 const sqldb = (module.exports = {});
@@ -30,7 +31,7 @@ sqldb.knexConfig = () => {
     },
   };
 
-  if (!config.postgres.connection_string) {
+  if (globals.isProd) {
     conf.connection = {
       host: config.postgres.host,
       user: config.postgres.user,

--- a/app/services/postgres.service.js
+++ b/app/services/postgres.service.js
@@ -11,19 +11,36 @@ const sqldb = (module.exports = {});
 /** @type {Knex?} Will store the knex instance reference */
 sqldb.knexCore = null;
 
-/** @type {Object} Knex configuration */
-sqldb.knexConfig = {
-  client: 'pg',
-  connection: config.postgres.connection_string,
-  migrations: {
-    directory: config.postgres.migrations.directory,
-  },
-  debug: false,
-  pool: {
-    min: config.postgres.pool_min,
-    max: config.postgres.pool_max,
-  },
-  ssl: { rejectUnauthorized: false },
+/**
+ * Generates appropriate PG config.
+ *
+ * @return {Object} knex config.
+ */
+sqldb.knexConfig = () => {
+  const conf = {
+    client: 'pg',
+    connection: config.postgres.connection_string,
+    migrations: {
+      directory: config.postgres.migrations.directory,
+    },
+    debug: false,
+    pool: {
+      min: config.postgres.pool_min,
+      max: config.postgres.pool_max,
+    },
+  };
+
+  if (!config.postgres.connection_string) {
+    conf.connection = {
+      host: config.postgres.host,
+      user: config.postgres.user,
+      password: config.postgres.password,
+      database: config.postgres.database,
+      ssl: { rejectUnauthorized: false },
+    };
+  }
+
+  return conf;
 };
 
 /**
@@ -35,7 +52,7 @@ sqldb.init = async () => {
   //
   // Connect to Main Data Store
   //
-  sqldb.knexCore = knex(sqldb.knexConfig);
+  sqldb.knexCore = knex(sqldb.knexConfig());
 
   log.notice('Connected to Postgres.');
 };

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -1,6 +1,9 @@
 {
     "postgres": {
-        "connection_string": "POSTGRES_URL"
+        "host": "PG_HOST",
+        "user": "PG_USER",
+        "password": "PG_PASSWORD",
+        "database": "PG_DATABASE"
     },
     "email": {
         "auth_password": "SKGBOT_EMAIL_AUTH_PASSWORD"

--- a/config/production.json
+++ b/config/production.json
@@ -4,5 +4,12 @@
     },
     "onboarding": {
         "verification_url": "https://verify.skgtech.io/verify/"
+    },
+    "postgres": {
+        "host": "USE ENV VAR",
+        "user": "USE ENV VAR",
+        "password": "USE ENV VAR",
+        "database": "USE ENV VAR",
+
     }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -9,7 +9,6 @@
         "host": "USE ENV VAR",
         "user": "USE ENV VAR",
         "password": "USE ENV VAR",
-        "database": "USE ENV VAR",
-
+        "database": "USE ENV VAR"
     }
 }


### PR DESCRIPTION
Heroku now forces SSL on PG connection, while doing is with self-signed certificates.

The workaround for this is to insert the `ssl: { rejectUnauthorized: false }` configuration in the `connection` property of the config. So in order to do this, the connectionString got replaced by host,user,pass,db properties.